### PR TITLE
Session variables generate messages select locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+.idea/vcs.xml
+.idea/workspace.xml

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,10 +6,10 @@ class ApplicationController < ActionController::Base
   $locations = @locations
 
   def reset_app
-    $alert_selected = ""
-    $emergency_selected = ""
-    # log out
-    $current_user = ""
+    cookies.delete :username
+    cookies.delete :alert
+    cookies.delete :emergency
+    cookies[:locations] = " "
     redirect_to login_path
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,36 +1,40 @@
 class PagesController < ApplicationController
 
+
+
 =begin
     These methods set the metadata for the alert that is being constructed.
 =end
 
 	def set_alert_test
+    cookies[:alert] = "TEST"
 		$alert_selected = "TEST"
 		redirect_to alert_path
 	end
 
 	def set_alert_live
+    cookies[:alert] = "LIVE"
 		$alert_selected = "LIVE"
 		redirect_to alert_path
-	end
+  end
 
 	def set_landslide_type
-		$emergency_selected = "Landslide"
+    cookies[:emergency] = "Landslide"
 		redirect_to alert_message_path
 	end
 
 	def set_flashflood_type
-  	$emergency_selected = "Flash Flood"
+    cookies[:emergency] = "Flash Flood"
   	redirect_to alert_message_path
   end
 
   def set_tsunami_type
-  	$emergency_selected = "Tsunami"
+    cookies[:emergency] = "Tsunami"
   	redirect_to alert_message_path
   end
 
   def set_missile_type
-  	$emergency_selected = "Missile"
+    cookies[:emergency] = "Missile"
   	redirect_to alert_message_path
   end
 
@@ -40,19 +44,26 @@ class PagesController < ApplicationController
 =end
 
   def wipe_alert_type
-    $alert_selected = ""
+    cookies[:alert] = ""
     redirect_to alert_type_path
   end
 
   def wipe_emergency_type
-    $emergency_selected = ""
+    cookies[:emergency] = ""
     redirect_to alert_path
   end
 
   def generate_message
-    @location = params[:location]
-    puts @location
-    puts "Generate Generic Message: "+"Please be advised. There is a "+$emergency_selected+" warning in effect for the areas: "+@location
+    $message = ""
+    $message = "Please be advised this is a "+ cookies[:alert] +" alert. There is a "+ cookies[:emergency] +" warning in effect for the areas: " + cookies[:locations]
+    redirect_to alert_message_path
+  end
+
+  def parse_comments
+    comments_from_form = params['myform']['comments']
+    #do your stuff with comments_from_form here
+    cookies[:locations] = comments_from_form
+    redirect_to alert_message_path
   end
 
   def create_alert

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,20 +1,16 @@
 class PagesController < ApplicationController
 
-
-
 =begin
     These methods set the metadata for the alert that is being constructed.
 =end
 
 	def set_alert_test
     cookies[:alert] = "TEST"
-		$alert_selected = "TEST"
 		redirect_to alert_path
 	end
 
 	def set_alert_live
     cookies[:alert] = "LIVE"
-		$alert_selected = "LIVE"
 		redirect_to alert_path
   end
 
@@ -54,8 +50,8 @@ class PagesController < ApplicationController
   end
 
   def generate_message
-    $message = ""
-    $message = "Please be advised this is a "+ cookies[:alert] +" alert. There is a "+ cookies[:emergency] +" warning in effect for the areas: " + cookies[:locations]
+    cookies[:message] = ""
+    cookies[:message] = "Please be advised this is a "+ cookies[:alert] +" alert. There is a "+ cookies[:emergency] +" warning in effect for the areas: " + cookies[:locations]
     redirect_to alert_message_path
   end
 
@@ -67,15 +63,11 @@ class PagesController < ApplicationController
   end
 
   def create_alert
-    @message = params[:message]
-    @location = params[:location]
-
-    puts "_______________________________________________________________"
-
-    puts @message
-    puts @location
-    @alert = Alert.new(alert_type: $alert_selected, emergency_type: $emergency_selected, affected_areas: @location, alert_message: @message, user: $current_user, status: "active")
+    puts "____________________________________________________________"
+    puts cookies[:locations]
+    @alert = Alert.new(alert_type: cookies[:alert], emergency_type: cookies[:emergency], affected_areas: cookies[:locations], alert_message: cookies[:message], user: cookies[:username], status: "active")
     if @alert.save
+       @message = ""
       redirect_to reset_app_path
     else
       render 'new'

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -14,6 +14,7 @@ class SessionController < ApplicationController
 		if account && account.authenticate(params[:session][:password])
 			# log in
 			$current_user = account.username
+			cookies[:username] = account.username
 			redirect_to alert_type_path
 		else
 			redirect_to login_path

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -5,6 +5,11 @@ class SessionController < ApplicationController
     Alert.all.each do |alert|
       puts alert.affected_areas
     end
+    cookies.delete :username
+    cookies.delete :alert
+    cookies.delete :emergency
+    cookies.delete :message
+    cookies[:locations] = " "
   end
 
 	def create
@@ -13,7 +18,6 @@ class SessionController < ApplicationController
 		account = Account.find_by(username: params[:session][:username])
 		if account && account.authenticate(params[:session][:password])
 			# log in
-			$current_user = account.username
 			cookies[:username] = account.username
 			redirect_to alert_type_path
 		else

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,9 +15,9 @@
 				<nav>
 				</nav>
 			</div>
-			<div class="navbar-brand"> Logged In: <%= $current_user %> </div>
-			<div class="navbar-brand"> Alert Type: <%= $alert_selected %> </div>
-			<div class="navbar-brand"> Emergency Type: <%= $emergency_selected %> </div>
+			<div class="navbar-brand"> Logged In: <%= cookies[:username] %> </div>
+			<div class="navbar-brand"> Alert Type: <%= cookies[:alert] %> </div>
+			<div class="navbar-brand"> Emergency Type: <%= cookies[:emergency] %> </div>
 			<div class="navbar-brand, pull-right">
 			   <%= link_to "Log Out", reset_app_path, class: 'navbar-brand', style: 'margin-top: 5%' %>
 			</div>

--- a/app/views/pages/alert_message.html.erb
+++ b/app/views/pages/alert_message.html.erb
@@ -11,7 +11,7 @@
 </script>
 <div class="jumbotron">
   <div class="row">
-    <div class="col-md-6 form-group">
+    <div class="form-group">
       <label for="exampleFormControlSelect2">Affected Area</label>
       <select multiple name="location[]" size="20" class="form-control" id="exampleFormControlSelect2">
         <% $locations.each do |location| %>
@@ -19,39 +19,35 @@
         <% end %>
       </select>
     </div>
-    <div class="col-md-6 form-group">
+    <div class="col-md-6">
       <label for="exampleFormControlSelect2">Areas Selected</label>
         <%= cookies[:locations] %>
     </div>
     <div>
       <%= form_tag :action => 'parse_comments' do %>
         <%= text_area :myform, :comments, :cols => '0', :rows => '0', :class => 'invisible' %>
-          <button class="btn btn-primary pull-right" onclick="myFunction()"><%= submit_tag "Select Areas", :class => 'btn btn-primary' %></button>
-      <% end %>
+          <button class="btn btn-primary pull-right" onclick="myFunction()"><%= submit_tag "Select Areas", :class => 'btn btn-primary pull-right' %></button>
+        <% end %>
     </div>
   </div>
-</div>
-
-<div class="jumbotron">
+  </br>
+  </br>
+  </br>
 
   <form action="create_alert">
-    <div class="row">
-
-      <div class="col-md-6 form-group">
+      <div class="form-group">
         <label for="exampleFormControlTextarea1">Alert Message</label>
-        <textarea name="message" class="form-control" id="exampleFormControlTextarea11" rows="17"><%= $message %></textarea>
+        <textarea name="message" class="form-control" id="exampleFormControlTextarea11" rows="17"><%= cookies[:message] %></textarea>
       </div>
-    </div>
 
     <div class="btn-toolbar">
-      <%= link_to "Back", redo_emergency_path, class: "btn btn-primary" %>
+      <!--TESTING-->
+      <%= link_to "Generate Message", generate_message_path, :class => 'btn btn-primary'%>
+      <!--TESTING-->
       <button type="submit" class="btn btn-primary pull-right">Send Alert</button>
     </div>
 
   </form>
-
-  <!--TESTING-->
-  <%= link_to "generate_message", generate_message_path, :class => 'btn btn-primary'%>
-  <!--TESTING-->
-  <button class="btn btn-primary pull-right" onclick="myFunction()">Generate Locations</button>
 </div>
+
+<%= link_to "Back", redo_emergency_path, class: "btn btn-primary" %>

--- a/app/views/pages/alert_message.html.erb
+++ b/app/views/pages/alert_message.html.erb
@@ -1,36 +1,45 @@
-<h1> <%= $alert_selected %> Alert</h1>
+<h1> <%= cookies[:alert] %> Alert</h1>
 
 <script>
 
     function myFunction() {
-        var type = '<%= $alert_selected %>';
-        var emergency = '<%= $emergency_selected %>'
-        var area = '<%= params[:location] %>'
-        alert(locations);
-        var message = type + " alert indiacting a " + emergency + " in " + area
-        document.getElementById('exampleFormControlTextarea1').value = message;
+        let messagelocations = $('.form-control').val();
+        messagelocations = messagelocations.join(', ') + " ";
+        document.getElementById('myform_comments').value = messagelocations;
     }
 
-    function myAlert(message) {
-        alert(message);
-    }
 </script>
+<div class="jumbotron">
+  <div class="row">
+    <div class="col-md-6 form-group">
+      <label for="exampleFormControlSelect2">Affected Area</label>
+      <select multiple name="location[]" size="20" class="form-control" id="exampleFormControlSelect2">
+        <% $locations.each do |location| %>
+          <option value="<%= location.location %>"><%= location.location %></option>
+        <% end %>
+      </select>
+    </div>
+    <div class="col-md-6 form-group">
+      <label for="exampleFormControlSelect2">Areas Selected</label>
+        <%= cookies[:locations] %>
+    </div>
+    <div>
+      <%= form_tag :action => 'parse_comments' do %>
+        <%= text_area :myform, :comments, :cols => '0', :rows => '0', :class => 'invisible' %>
+          <button class="btn btn-primary pull-right" onclick="myFunction()"><%= submit_tag "Select Areas", :class => 'btn btn-primary' %></button>
+      <% end %>
+    </div>
+  </div>
+</div>
 
 <div class="jumbotron">
+
   <form action="create_alert">
     <div class="row">
-      <div class="col-md-6 form-group">
-        <label for="exampleFormControlSelect2">Affected Area</label>
-        <select multiple name="location[]" size="20" class="form-control" id="exampleFormControlSelect2">
-          <% $locations.each do |location| %>
-            <option><%= location.location %></option>
-          <% end %>
-        </select>
-      </div>
 
       <div class="col-md-6 form-group">
         <label for="exampleFormControlTextarea1">Alert Message</label>
-        <textarea name="message" class="form-control" id="exampleFormControlTextarea1" rows="17"></textarea>
+        <textarea name="message" class="form-control" id="exampleFormControlTextarea11" rows="17"><%= $message %></textarea>
       </div>
     </div>
 
@@ -40,5 +49,9 @@
     </div>
 
   </form>
-  <button class="btn btn-primary pull-right" onclick="myFunction()">Create Message</button>
+
+  <!--TESTING-->
+  <%= link_to "generate_message", generate_message_path, :class => 'btn btn-primary'%>
+  <!--TESTING-->
+  <button class="btn btn-primary pull-right" onclick="myFunction()">Generate Locations</button>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,12 +24,15 @@ Rails.application.routes.draw do
 	get 'tsunami_button' => 'pages#set_tsunami_type'
 	get 'missile_button' => 'pages#set_missile_type'
   get 'create_alert'  => 'pages#create_alert'
-  get 'generate_message' => 'pages#generate_message'
 
   get 'redo_type' =>  'pages#wipe_alert_type'
 	get 'redo_emergency' => 'pages#wipe_emergency_type'
 
 	get 'reset_app' => 'application#reset_app'
+
+	get 'generate_message' => "pages#generate_message"
+  get 'parse_comments' => "pages#parse_comments"
+  post 'parse_comments' => "pages#parse_comments"
 
 	resources :accounts
 	resources :alert


### PR DESCRIPTION
- Adjusted site to use cookies for storage
     - This is to fix a bug where concurrent users would overwrite each other's selections.
- Split the locations selection away from the message form to allow users to submit locations first, then generate a message based on all previously selected variables.
    - Alert message layout adjusted to better reflect the adjustment in functionality.